### PR TITLE
Add File instance support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ EMFLAGS = \
 	-s EXPORTED_RUNTIME_METHODS=@src/exported_runtime_methods.json \
 	-s SINGLE_FILE=0 \
 	-s NODEJS_CATCH_EXIT=0 \
-	-s NODEJS_CATCH_REJECTION=0
+	-s NODEJS_CATCH_REJECTION=0 \
+	-lworkerfs.js
 
 EMFLAGS_ASM = \
 	-s WASM=0


### PR DESCRIPTION

**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
Database constructor argument is changed from a single `data` argument to an optional options object with `data` or `file` fields.

**Description**
<!-- describe what has changed, and motivation behind those changes -->

Prior to this change, the only way to read a file was to load the entire contents into an ArrayBuffer and pass the entire array to the Database constructor. This restricted large files from being accessible since browsers have limits on how much data they can load into memory.

This change adds File instance support to the Database constructor. This allows for reading arbitrary size files without loading the file into memory first. This is accomplished by using the WORKERFS (https://emscripten.org/docs/api_reference/Filesystem-API.html#workerfs) emscripted file system to access the file content. The limitation is that it requires accessing the database from within a webworker.



<!-- link relevant GitHub issues -->
